### PR TITLE
Percent encoding for "+" sign

### DIFF
--- a/APIClient/Request.swift
+++ b/APIClient/Request.swift
@@ -69,7 +69,7 @@ public struct Request<ResponseBody> {
                 var components = URLComponents()
                 components.queryItems = raw.compactMap {
                     if let value = $0.value {
-                        return URLQueryItem(name: $0.key, value: value)
+                        return URLQueryItem(name: $0.key, value: value.addingPercentEncoding(withAllowedCharacters: .alphanumerics))
                     }
                     return nil
                 }


### PR DESCRIPTION
URLComponentsは`+`をエンコードしないので、 `kishikawakatsumi+jp@gmail.com` のようなメールアドレスをFormパラメータとしてうまく扱えない。

http://www.openradar.me/40751862
https://www.djackson.org/why-we-do-not-use-urlcomponents/